### PR TITLE
Improve data-model schema validator

### DIFF
--- a/modules/crud/data-model-json-schema-validator-npm-package/src/validator.test.ts
+++ b/modules/crud/data-model-json-schema-validator-npm-package/src/validator.test.ts
@@ -1,5 +1,5 @@
 import SCHEMA__1_0 from '../../data-model-json-schema/1.0.json'
-import { determineSchemaVersionFromDataModel, getSchema, validate, validateAgainstSchema } from './validator'
+import { determineSchemaVersionFromDataModel, getSchema, getValidator, validate, validateAgainstSchema } from './validator'
 
 describe('determineSchemaVersionFromDataModel', () => {
   it('should return 1.0', () => {
@@ -46,6 +46,19 @@ describe('getSchema', () => {
 
   it('should throw error for a random string version', () => {
     expect(() => getSchema('asddsadsaasd')).toThrow(/Unknown schema version/)
+  })
+})
+
+describe('getValidator', () => {
+  it('should return the same compiled validator on subsequent calls', () => {
+    const first = getValidator('1.0')
+    const second = getValidator('1.0')
+
+    expect(first).toBe(second)
+  })
+
+  it('should throw error on UNKNOWN version', () => {
+    expect(() => getValidator('UNKNOWN' as any)).toThrow(/Unknown schema version/)
   })
 })
 

--- a/modules/crud/data-model-json-schema-validator-npm-package/src/validator.ts
+++ b/modules/crud/data-model-json-schema-validator-npm-package/src/validator.ts
@@ -1,39 +1,69 @@
-import Ajv, { ValidateFunction } from 'ajv'
+import Ajv, { ValidateFunction, ErrorObject } from 'ajv'
 import SCHEMA__1_0 from '../../data-model-json-schema/1.0.json'
 
 type Schema = object
-type DataModel = any
-type SchemaVersion = '1.0' | 'UNKNOWN'
+type DataModel = unknown
+export type SchemaVersion = '1.0' | 'UNKNOWN'
 
-interface ValidationResult {
+export interface ValidationResult {
   valid: boolean
   schemaVersion: SchemaVersion
-  errors?: ValidateFunction['errors']
+  errors?: ErrorObject[] | null
 }
 
 export function determineSchemaVersionFromDataModel (dataModel: DataModel): SchemaVersion {
-  return (dataModel?.spec_version === '1.0')
+  return (typeof dataModel === 'object' && dataModel !== null && (dataModel as any).spec_version === '1.0')
     ? '1.0'
     : 'UNKNOWN'
 }
 
-export function getSchema (schemaVersion: SchemaVersion | any): Schema {
-  if (schemaVersion === '1.0') {
-    return SCHEMA__1_0
+const SCHEMAS: Record<Exclude<SchemaVersion, 'UNKNOWN'>, Schema> = {
+  '1.0': SCHEMA__1_0,
+}
+
+export function getSchema (schemaVersion: SchemaVersion | string): Schema {
+  const schema = (SCHEMAS as Record<string, Schema>)[schemaVersion]
+  if (!schema) {
+    throw new Error('Unknown schema version')
   }
 
-  throw new Error('Unknown schema version')
+  return schema
+}
+
+const ajv = new Ajv({ allErrors: true })
+const validatorCache = new WeakMap<Schema, ValidateFunction>()
+
+const versionCache: Partial<Record<Exclude<SchemaVersion, 'UNKNOWN'>, ValidateFunction>> = {}
+
+export function getValidator (schemaVersion: SchemaVersion): ValidateFunction {
+  if (schemaVersion === 'UNKNOWN') {
+    throw new Error('Unknown schema version')
+  }
+
+  let validateFn = versionCache[schemaVersion]
+  if (!validateFn) {
+    const schema = getSchema(schemaVersion)
+    validateFn = ajv.compile(schema)
+    versionCache[schemaVersion] = validateFn
+  }
+
+  return validateFn
 }
 
 export function validateAgainstSchema (schema: Schema, dataModel: DataModel): ValidationResult {
-  const ajv = new Ajv({ allErrors: true })
-  const validate = ajv.compile(schema)
-  const isValid = validate(dataModel)
+  let validateFn = validatorCache.get(schema)
+
+  if (!validateFn) {
+    validateFn = ajv.compile(schema)
+    validatorCache.set(schema, validateFn)
+  }
+
+  const isValid = validateFn(dataModel)
 
   return {
-    valid: isValid,
+    valid: Boolean(isValid),
     schemaVersion: determineSchemaVersionFromDataModel(dataModel),
-    ...(isValid ? {} : { errors: validate.errors }),
+    ...(isValid ? {} : { errors: validateFn.errors }),
   }
 }
 


### PR DESCRIPTION
## Summary
- refactor validator with cached AJV instances
- expose `getValidator` for reusing compiled schemas
- tighten types and expand test coverage

## Testing
- `npm test` in `modules/crud/data-model-json-schema-validator-npm-package`

------
https://chatgpt.com/codex/tasks/task_b_683a302e0d0c8332bb06bd9b7725077a